### PR TITLE
Plt/fix fmt uint64

### DIFF
--- a/src/decoder.c
+++ b/src/decoder.c
@@ -205,8 +205,9 @@ static int _get_and_advance_int32(nanocbor_value_t *cvalue, int32_t *value, uint
 
 int nanocbor_get_int8(nanocbor_value_t *cvalue, int_least8_t *value)
 {
+#define C2000_INT8_MAX 127  // C2000 does not define INT8_MAX, because it doesnt implement int8_t
     int32_t tmp = 0;
-    int res = _get_and_advance_int32(cvalue, &tmp, NANOCBOR_SIZE_BYTE, INT8_MAX);
+    int res = _get_and_advance_int32(cvalue, &tmp, NANOCBOR_SIZE_BYTE, C2000_INT8_MAX);
 
     *value = (int_least8_t)tmp;
 

--- a/src/encoder.c
+++ b/src/encoder.c
@@ -63,7 +63,7 @@ static int _fmt_uint64(nanocbor_encoder_t *enc, uint64_t num, uint_least8_t type
             type |= NANOCBOR_SIZE_WORD;
             extrabytes = sizeof(uint32_t);
         }
-        else if (num > UINT8_MAX) {
+        else if (num > 255/* UINT8_MAX - C2000 does not define this*/ ) {
             type |= NANOCBOR_SIZE_SHORT;
             extrabytes = sizeof(uint16_t);
         }


### PR DESCRIPTION
This creates an explicit uint_least8_t array rather than relying on a subset of a big endin uint64_t.